### PR TITLE
Added function to plot PDFs associated with Poly.

### DIFF
--- a/equadratures/parameter.py
+++ b/equadratures/parameter.py
@@ -171,7 +171,7 @@ class Parameter(object):
         :param numpy.array data: 
             Samples from the distribution (or a similar one) that need to be plotted as a histogram.
         """
-        return plot.plot_pdf(self,ax=None, data=None, show=True)
+        return plot.plot_pdf(self,ax, data, show)
     def _set_moments(self):
         """
         Private function that sets the mean and the variance of the distribution.

--- a/equadratures/plot.py
+++ b/equadratures/plot.py
@@ -549,7 +549,53 @@ def plot_pdf(Parameter, ax=None, data=None, show=True):
     if data is not None:
         ax.hist(data, 50, density=True, facecolor='dodgerblue', alpha=0.7, label='Data', edgecolor='white')
     ax.legend()
-    sns.despine(offset=10, trim=True)
+    sns.despine(ax=ax, offset=10, trim=True)
+    if show:
+        plt.show()
+    return fig, ax
+
+def _trim_axs(ax,N):
+    """
+    Private function to reduce *axs* to *N* axes. All further axes are removed from the figure.
+    :param matplotlib.ax ax: 
+        An instance of the ``matplotlib`` axes class to plot onto. 
+    :param int N: 
+        The number of axes to reduce the subplot to.
+    :return:
+        **ax**: An instance of the ``matplotlib`` axes class, reduced to size *N*.
+
+    """
+    ax = ax.flat
+    for a in ax[N:]:
+        a.remove()
+    return ax[:N]
+
+def plot_parameters(Polynomial, ax=None, cols=2, show=True):
+    """
+    Plots the probability density functions for all Parameters within a Polynomial.
+    :param Poly Polynomial: 
+        An instance of the Polynomial class.
+    :param matplotlib.ax ax: 
+        An instance of the ``matplotlib`` axes class to plot onto. If ``None``, a new figure and axes are created (default: ``None``).
+    :param int cols: 
+        The number of columns to organise the parameter PDF plots into.
+    :param bool show: 
+        Option to show the graph.
+    :return:
+        **fig**: An instance of the ``matplotlib`` figure class, containing the generated axes.
+    :return:
+        **ax**: An instance of the ``matplotlib`` axes class, containing a plot of the PDF.
+    """
+    rows = len(Polynomial.parameters) // cols + 1
+    if ax is None:
+        fig, ax = plt.subplots(rows, cols, figsize=(8*cols, 6*rows), tight_layout=True)
+        ax = _trim_axs(ax, len(Polynomial.parameters))
+    else:
+        fig = ax.figure  
+    for a, param in zip(ax, Polynomial.parameters):
+        plot_pdf(param, ax=a, show=False)
+        a.set_xlabel(param.variable.capitalize())
+        a.set_ylabel('PDF')
     if show:
         plt.show()
     return fig, ax

--- a/equadratures/poly.py
+++ b/equadratures/poly.py
@@ -192,6 +192,26 @@ class Poly(object):
             Dictionary of keyword arguments to pass to matplotlib.bar() function.  
         """
         return plot.plot_sobol(self,ax,order,show,labels,kwargs)
+
+    def plot_parameters(self, ax=None, cols=2, show=True):
+        """
+        Plots the probability density functions for all Parameters within a Polynomial.
+        :param Poly self: 
+            An instance of the Polynomial class.
+        :param matplotlib.ax ax: 
+            An instance of the ``matplotlib`` axes class to plot onto. If ``None``, a new figure and axes are created (default: ``None``).
+        :param int cols: 
+            The number of columns to organise the parameter PDF plots into.
+        :param bool show: 
+            Option to show the graph.
+        :return:
+            **fig**: An instance of the ``matplotlib`` figure class, containing the generated axes.
+        :return:
+            **ax**: An instance of the ``matplotlib`` axes class, containing a plot of the PDF.
+        """
+        return plot.plot_parameters(self, ax, cols, show)
+
+
     def plot_total_sobol(self, ax=None, show=True, labels=None, kwargs={}):
         """
         Plots a polynomial's total-order Sobol' indices.


### PR DESCRIPTION
@ascillitoe following on from the discourse I added a function to plot all of the PDF's from parameters associated with a polynomial. Please review and clean up as you see fit - no worries if you have other ideas on how to do this and don't use it - I just thought I'd offer this up as I already had most of it written from existing work.

Essentially it does a loop through Polynomial.parameters and calls the existing `plot.plot_pdf` function. To allow a little bit of customisation I include a cols argument to allow you to specify the number of columns to put the parameters in.

I also noticed a bug in `plot_pdf` where the defaults were specified in the return making it impossible to change them. I've just removed this so it now gives the expected behaviour.

I also spotted some odd behaviour in the axes from `plot_pdf` when putting it into a subplot. After some digging this was because of the `sns.despine` call which was trimming everything. The fix was to add `ax=ax` into it so it was more targeted.

